### PR TITLE
change_street_names script

### DIFF
--- a/cleaning/change_street_names.py
+++ b/cleaning/change_street_names.py
@@ -1,0 +1,84 @@
+import xml.etree.ElementTree as et
+import os
+import re
+import sys
+
+
+north_regex = re.compile('^(N )')
+blvd_regex = re.compile(r'( Blvd)$')
+ct_regex = re.compile('( Ct)$')
+pl_regex = re.compile('( Pl)$')
+st_regex = re.compile('( St)$')
+
+
+class BuildingNode:
+    def __init__(self, building):
+        self.id = building.attrib['id']
+        self.street = None
+        self.city = None
+        for tag in building:
+            if tag.get('k') == "addr:street":
+                self.street = tag.get('v')
+            if tag.get('k') == "addr:city":
+                self.city = tag.get('v')
+
+
+def main():
+    ways = root.findall("./way")
+    for bldg in ways:
+        building = BuildingNode(bldg)
+        if building.street is None:
+            continue
+        my_street = change_street_name(building.street, building.city)
+        if my_street != str(building.street):  # Checks if the street name needs to be changed
+            for tag in bldg:
+                if (tag.get('k')) == "addr:street":
+                    tag.set('v', my_street)
+
+    tree.write(output, encoding='utf-8', xml_declaration=True)
+
+    try:    # Make sure the file line lengths of source and update files are the same
+        assert get_file_length(output) == source_file_length
+    except AssertionError as e:
+        print("Warning: File length of updated file does not match source file length! \n{}".format(e))
+        os.remove(output)
+
+
+def change_street_name(street_name, city):
+    street_name, city = str(street_name), str(city)
+    if city == "Denver":
+        if north_regex.match(street_name):
+            street_name = street_name[2:]
+    if blvd_regex.search(street_name):
+        street_name = street_name[:-4] + "Boulevard"
+    if ct_regex.search(street_name):
+        street_name = street_name[:-2] + "Court"
+    if pl_regex.search(street_name):
+        street_name = street_name[:-2] + "Place"
+    if st_regex.search(street_name):
+        street_name = street_name[:-2] + "Street"
+    return street_name
+
+
+def get_file_length(fname):
+    with open(fname) as f:
+        for i, l in enumerate(f):
+            pass
+        return i + 1
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("This script needs an input file path as the argument")
+        exit()
+    osm_source = sys.argv[1]
+    if len(sys.argv) == 3:
+        output = sys.argv[2]
+    else:
+        output = str(osm_source).split('.')
+        output.insert(-1, 'update.')
+        output = ''.join(output)
+    tree = et.parse(osm_source)
+    root = tree.getroot()
+    source_file_length = get_file_length(osm_source)
+    main()

--- a/cleaning/test_change_street_names.py
+++ b/cleaning/test_change_street_names.py
@@ -1,0 +1,33 @@
+from change_street_names import change_street_name as csn
+import unittest
+
+
+class TestStreetChange(unittest.TestCase):
+
+    def test_north_street_cases(self):
+        self.assertEqual(csn('N Galapago St', 'Denver'), "Galapago Street")
+        self.assertEqual(csn('North Galapago St', 'Denver'), "North Galapago Street")
+        self.assertEqual(csn('S Galapago St', 'Denver'), "S Galapago Street")
+        self.assertEqual(csn('Galapago St North', 'Denver'), "Galapago St North")
+        self.assertEqual(csn('N Galapago St', 'Aurora'), "N Galapago Street")
+        self.assertEqual(csn('Galapago N Blvd', 'Denver'), "Galapago N Boulevard")
+
+    def test_street_abbrev(self):
+        self.assertEqual(csn('Blvd Galapago N', 'Denver'), "Blvd Galapago N")
+        self.assertEqual(csn('N Galapago Way', 'Denver'), "Galapago Way")
+        self.assertEqual(csn('E Galapago Blvd St', 'Denver'), "E Galapago Blvd Street")
+        self.assertEqual(csn('Blvd Galapago Pl', 'Aurora'), "Blvd Galapago Place")
+        self.assertEqual(csn('N Galapago Ave', 'Commerce City'), "N Galapago Ave")
+        self.assertEqual(csn('N Galapago Ct Ct', 'Denver'), "Galapago Ct Court")
+        self.assertEqual(csn('Blvd Galapago N', 'St'), "Blvd Galapago N")
+        self.assertEqual(csn('E Galapago Place', 'Denver'), "E Galapago Place")
+        self.assertEqual(csn('W First', 'Denver'), "W First")
+        self.assertEqual(csn('N First', 'Denver'), "First")
+        self.assertEqual(csn('W FirSt', 'Denver'), "W FirSt")
+        self.assertEqual(csn('W FirSt St', 'Denver'), "W FirSt Street")
+        self.assertEqual(csn('', ''), "")
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This script searches thru the .osm xml file and does two things:
1) Finds common street abbreviations: St, Pl, Ct, Blvd and spells them out (i.e. Blvd becomes Boulevard)
2) Finds streets in _Denver only_ that are prefixed with "N " (i.e. "N Galapago St") and removes the "N ". ("N Galapago St" becomes "Galapago Street")

This is a command line script that takes 1 or 2 (2nd is optional) arguments. First argument is the source file, second argument is an optional new output name. If no second argument is provided then "update" is added to the file root name.

There is also a unittest script that checks that the function properly works.